### PR TITLE
OXT-1829 Fix the process of removing a USB

### DIFF
--- a/src/xenusbdevice/Device.cpp
+++ b/src/xenusbdevice/Device.cpp
@@ -740,6 +740,7 @@ XenDeconfigure(IN PUSB_FDO_CONTEXT fdoContext)
     AcquireFdoLock(fdoContext);
     if (!fdoContext->XenConfigured)
     {
+        ReleaseFdoLock(fdoContext);
         return STATUS_SUCCESS;
     }
     fdoContext->XenConfigured = FALSE;
@@ -856,7 +857,6 @@ CleanupDisconnectedDevice(
         ReleaseFdoLock(fdoContext);
         return;
     }
-    fdoContext->CtlrDisconnected = TRUE;
 
     ReleaseFdoLock(fdoContext);
     WdfTimerStop(fdoContext->WatchdogTimer, TRUE);
@@ -869,6 +869,7 @@ CleanupDisconnectedDevice(
     AcquireFdoLock(fdoContext);
 
     FdoUnplugDevice(fdoContext);
+    fdoContext->CtlrDisconnected = TRUE;
 
     BOOLEAN completeRequest = TRUE;
 


### PR DESCRIPTION
Devices still exist from guest perspective after being removed from
dom0. The following changes here and in xenvusb.git ensure USBs appear
removed from guest perspective for all types of removals, including
while the guest is asleep.

* fdoContext spinlock should be released before returning regardless if
  xenConfigured is true or false
* CtlrDisconnected should be set to TRUE after calling FdoUnplugDevice.
  Within this function, child devices are not removed if the
  CtlrDisconnected is already TRUE

Signed-off-by: Bryer Esengard <esengardb@ainfosec.com>