### PR TITLE
Updating build files to work with newer EWDK

### DIFF
--- a/vs2019/package/package.vcxproj
+++ b/vs2019/package/package.vcxproj
@@ -57,6 +57,11 @@
   <ItemGroup>
     <PackageFiles Include="$(OutDir)\$(ProjectName)\*" />
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
+  </ItemDefinitionGroup>
   <Target Name="Archive" AfterTargets="TestSign">
     <Copy SourceFiles="@(PackageFiles)" DestinationFiles="@(PackageFiles->'$(ArchiveDir)\%(FileName)%(Extension)')" />
   </Target>

--- a/vs2019/version/version.vcxproj
+++ b/vs2019/version/version.vcxproj
@@ -10,6 +10,11 @@
     <IncludeDir>..\..\include</IncludeDir>
     <SourceDir>..\..\src</SourceDir>
   </PropertyGroup>
+  <Target Name="GetProjectInfoForReference" Returns="@(ProjectInfoForReference)">
+    <ItemGroup>
+      <ProjectInfoReference Include="@(LibFullPath)" />
+    </ItemGroup>
+  </Target>
   <Target Name="Build">
     <Exec Command="powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File $(Script) $(Platform) $(SolutionDir) $(IncludeDir) $(SourceDir)" />
   </Target>

--- a/vs2019/xenusbdevice/xenusbdevice.vcxproj
+++ b/vs2019/xenusbdevice/xenusbdevice.vcxproj
@@ -30,7 +30,7 @@
       <AdditionalIncludeDirectories>..\..\include;..\..\include\xen;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>__MODULE__="XENUSBDEVICE";POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DisableSpecificWarnings>4464;4711;4548;4820;4668;4255;5045;6001;6054;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4061;4464;4711;4548;4820;4668;4255;5045;6001;6054;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnablePREfast>true</EnablePREfast>
       <TreatWarningAsError>false</TreatWarningAsError>
@@ -48,6 +48,9 @@
       <SpecifyDriverVerDirectiveVersion>true</SpecifyDriverVerDirectiveVersion>
       <EnableVerbose>true</EnableVerbose>
     </Inf>
+    <DriverSign>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
     <ClCompile>


### PR DESCRIPTION
Older EWDKs have been deprecated and build requires updates to match latest Win10 EWDK requirements