### PR TITLE
Fix warnings

### DIFF
--- a/src/xenusbdevice/Device.cpp
+++ b/src/xenusbdevice/Device.cpp
@@ -1454,7 +1454,7 @@ InitScratchpad(
     NTSTATUS status;
     KeInitializeEvent(&fdoContext->ScratchPad.CompletionEvent, NotificationEvent, FALSE);
 
-    fdoContext->ScratchPad.Buffer = ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE, XVU1);
+    fdoContext->ScratchPad.Buffer = ExAllocatePool2(POOL_FLAG_NON_PAGED, PAGE_SIZE, XVU1);
     if (!fdoContext->ScratchPad.Buffer)
     {
         status =  STATUS_NO_MEMORY;

--- a/src/xenusbdevice/Queue.cpp
+++ b/src/xenusbdevice/Queue.cpp
@@ -444,7 +444,7 @@ AllocAndQueryPropertyString(
     }
     // C6102		Using '*ResultLength' from failed function call.
 #pragma warning(suppress: 6102)
-    buffer = (PWCHAR) ExAllocatePoolWithTag(PagedPool, *ResultLength, '2UVX');
+    buffer = (PWCHAR) ExAllocatePool2(POOL_FLAG_PAGED, *ResultLength, '2UVX');
     if (!buffer)
     {
         return NULL;

--- a/src/xenusbdevice/RootHubPdo.cpp
+++ b/src/xenusbdevice/RootHubPdo.cpp
@@ -868,13 +868,13 @@ HubQueueInitialize(
 
 USB_HUB_DESCRIPTOR RootHubDescriptor =
 {
-    0x09,  // bDescLength
-    0x29,  // bDescriptorType
-    0x01,  // bNbrPorts
-    0x1b,  // wHubCharacteristics ? or 0x01
-    0x00,  // bPwrOn2PwrGood
-    0x00,  // bHubContrCurrent
-    0x00,  // DeviceRemovable
+    0x09,     // bDescriptorLength
+    0x29,     // bDescriptorType
+    0x01,     // bNumberOfPorts
+    0x1b,     // wHubCharacteristics ? or 0x01
+    0x00,     // bPowerOn2PowerGood
+    0x00,     // bHubControlCurrent
+    { 0x00 }, // bRemoveAndPowerMask
 };
 
 /**
@@ -1962,10 +1962,8 @@ HubGetStatus(
                                 __FUNCTION__": Device %p clearing port feature reset status\n",
                                 hubContext->WdfDevice);
                 }
-                ULONG level = hubContext->PortFeatureChange ? TRACE_LEVEL_WARNING :
-                              TRACE_LEVEL_VERBOSE;
 
-                TraceEvents(level, TRACE_URB,
+                TraceEvents(hubContext->PortFeatureChange ? TRACE_LEVEL_WARNING : TRACE_LEVEL_VERBOSE, TRACE_URB,
                             __FUNCTION__": Device %p Port Status %x Change %x\n",
                             hubContext->WdfDevice,
                             portStatus->AsUshort16,

--- a/src/xenusbdevice/UsbConfig.cpp
+++ b/src/xenusbdevice/UsbConfig.cpp
@@ -125,14 +125,10 @@ static VOID
 TraceScratchStatus(IN PUSB_FDO_CONTEXT fdoContext,
                    IN CONST CHAR *function)
 {
-    // --XT-- The stalled status does not seem like an error, downgrading
-    // to a warning.
-    ULONG level = (fdoContext->ScratchPad.Status == USBD_STATUS_STALL_PID) ?
-                  TRACE_LEVEL_WARNING : TRACE_LEVEL_ERROR;
-
-    TraceEvents(level, TRACE_DEVICE, "%s: %s usb status %x returned\n",
-                function, fdoContext->FrontEndPath,
-                fdoContext->ScratchPad.Status);
+    // --XT-- The stalled status does not seem like an error, downgrading to a warning.
+    TraceEvents((fdoContext->ScratchPad.Status == USBD_STATUS_STALL_PID) ? TRACE_LEVEL_WARNING : TRACE_LEVEL_ERROR, TRACE_DEVICE,
+        "%s: %s usb status %x returned\n", function, fdoContext->FrontEndPath, fdoContext->ScratchPad.Status
+    );
 }
 
 NTSTATUS
@@ -543,8 +539,8 @@ GetDeviceDescriptor(
         //
         // allocate the array of config data based on the device descriptor
         //
-        fdoContext->ConfigData = (PUSB_CONFIG_INFO) ExAllocatePoolWithTag(
-                                     NonPagedPool,
+        fdoContext->ConfigData = (PUSB_CONFIG_INFO) ExAllocatePool2(
+                                     POOL_FLAG_NON_PAGED,
                                      fdoContext->DeviceDescriptor.bNumConfigurations * sizeof(USB_CONFIG_INFO),
                                      XVU3);
         if (!fdoContext->ConfigData)
@@ -724,7 +720,7 @@ GetAllConfigDescriptors(
                     // need to offset bConfigurationValue
                     //
                     status = SetCurrentConfiguration(fdoContext,
-                                                     defaultDesc->bConfigurationValue + fdoContext->CurrentConfigOffset);
+                                                     (UCHAR)(defaultDesc->bConfigurationValue + fdoContext->CurrentConfigOffset));
                 }
                 else
                 {
@@ -743,7 +739,7 @@ GetAllConfigDescriptors(
 UCHAR CurrentConfigValue(
     IN PUSB_FDO_CONTEXT fdoContext)
 {
-    return (fdoContext->CurrentConfigValue - fdoContext->CurrentConfigOffset);
+    return (UCHAR)(fdoContext->CurrentConfigValue - fdoContext->CurrentConfigOffset);
 }
 
 PUSB_CONFIGURATION_DESCRIPTOR
@@ -1162,7 +1158,7 @@ GetCompleteConfigDescriptor(
         ExFreePool(configInfo->m_configurationDescriptor);
     }
     configInfo->m_configurationDescriptor = (PUSB_CONFIGURATION_DESCRIPTOR)
-                                            ExAllocatePoolWithTag(NonPagedPool, length, XVU4);
+                                            ExAllocatePool2(POOL_FLAG_NON_PAGED, length, XVU4);
     if (!configInfo->m_configurationDescriptor)
     {
         TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
@@ -1209,7 +1205,7 @@ GetCompleteConfigDescriptor(
     // allocate interface pointers and pipe_descriptor pointers
     //
     configInfo->m_interfaceDescriptors = (PUSB_INTERFACE_DESCRIPTOR *)
-                                         ExAllocatePoolWithTag(NonPagedPool,
+                                         ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                                  (configInfo->m_numInterfaces * sizeof(PUSB_INTERFACE_DESCRIPTOR *)),
                                                  XVU5);
     if (!configInfo->m_interfaceDescriptors)
@@ -1230,7 +1226,7 @@ GetCompleteConfigDescriptor(
     if (configInfo->m_numEndpoints)
     {
         configInfo->m_pipeDescriptors = (PIPE_DESCRIPTOR *)
-                                        ExAllocatePoolWithTag(NonPagedPool,
+                                        ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                                 (configInfo->m_numEndpoints * sizeof(PIPE_DESCRIPTOR)),
                                                 XVU6);
         if (!configInfo->m_pipeDescriptors)
@@ -1616,8 +1612,7 @@ GetOsDescriptorString(
             break;
         }
 
-        USHORT length = (compatIds->header.bCount * (USHORT) sizeof(OS_COMPATID_FUNCTION)) +
-                        (USHORT) sizeof(OS_FEATURE_HEADER);
+        USHORT length = (USHORT)((compatIds->header.bCount * sizeof(OS_COMPATID_FUNCTION)) + sizeof(OS_FEATURE_HEADER));
         if (length != compatIds->header.dwLength)
         {
             TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
@@ -1704,7 +1699,7 @@ GetOsDescriptorString(
             Status = STATUS_UNSUCCESSFUL;
             break;
         }
-        fdoContext->CompatIds = (POS_COMPAT_ID) ExAllocatePoolWithTag(NonPagedPool,
+        fdoContext->CompatIds = (POS_COMPAT_ID) ExAllocatePool2(POOL_FLAG_NON_PAGED,
                                 length,
                                 XVU7);
         if (!fdoContext->CompatIds)
@@ -1770,7 +1765,7 @@ GetString(
     UCHAR index)
 {
     PUSB_STRING uString =
-        (PUSB_STRING) ExAllocatePoolWithTag(NonPagedPool, sizeof(USB_STRING), XVU8);
+        (PUSB_STRING) ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(USB_STRING), XVU8);
     if (!uString)
     {
         TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,

--- a/src/xenusbdevice/UsbInterface.cpp
+++ b/src/xenusbdevice/UsbInterface.cpp
@@ -1300,7 +1300,7 @@ RootHubIfGetExtendedHubInformation (
     hubInfo->Port[0].PortAttributes = USB_PORTATTR_SHARED_USB2; // @todo anything else here?
     hubInfo->Port[0].PidOverride = 0;
     hubInfo->Port[0].VidOverride = 0;
-    *LengthOfDataCopied = FIELD_OFFSET(USB_EXTHUB_INFORMATION_0, Port[0]); // length of valid data.
+    *LengthOfDataCopied = (ULONG)FIELD_OFFSET(USB_EXTHUB_INFORMATION_0, Port[0]); // length of valid data.
     return STATUS_SUCCESS;
 }
 
@@ -1986,10 +1986,7 @@ RootHubIfFpAllocateWorkItem(
     _In_opt_ PDEVICE_OBJECT Pdo)
 {
     ULONG workItemSize = IoSizeofWorkItem();
-    PIO_WORKITEM workitem = (PIO_WORKITEM) ExAllocatePoolWithTag(
-                                NonPagedPoolNx,
-                                workItemSize,
-                                XVUG);
+    PIO_WORKITEM workitem = (PIO_WORKITEM) ExAllocatePool2(POOL_FLAG_NON_PAGED, workItemSize, XVUG);
 
     TraceEvents(TRACE_LEVEL_VERBOSE, TRACE_DEVICE,
                 __FUNCTION__": Pdo %p\n",
@@ -2091,8 +2088,8 @@ ProcessIrpWorkItem(
 PIRP_WORK_ITEM
 AllocateIrpWorkItem()
 {
-    PIRP_WORK_ITEM irpItem =  (PIRP_WORK_ITEM) ExAllocatePoolWithTag(NonPagedPool,
-                              sizeof(IRP_WORK_ITEM), XVUH);
+    PIRP_WORK_ITEM irpItem =  (PIRP_WORK_ITEM) ExAllocatePool2(POOL_FLAG_NON_PAGED,
+        sizeof(IRP_WORK_ITEM), XVUH);
     if (irpItem)
     {
         RtlZeroMemory(irpItem, sizeof(IRP_WORK_ITEM));

--- a/src/xenusbdevice/UsbResponse.cpp
+++ b/src/xenusbdevice/UsbResponse.cpp
@@ -62,12 +62,8 @@ PostProcessScratch(
     }
     if (fdoContext->ScratchPad.Status != USBD_STATUS_SUCCESS)
     {
-        // --XT-- The stalled status does not seem like an error, downgrading
-        // to a warning.
-        ULONG level = (fdoContext->ScratchPad.Status == USBD_STATUS_STALL_PID) ?
-                      TRACE_LEVEL_WARNING : TRACE_LEVEL_ERROR;
-
-        TraceEvents(level, TRACE_DPC,
+        // --XT-- The stalled status does not seem like an error, downgrading to a warning.
+        TraceEvents((fdoContext->ScratchPad.Status == USBD_STATUS_STALL_PID) ? TRACE_LEVEL_WARNING : TRACE_LEVEL_ERROR, TRACE_DPC,
                     __FUNCTION__": %s Scratch request error %x usbif %s usbd %s\n",
                     fdoContext->FrontEndPath,
                     usbdStatus,

--- a/src/xenusbdevice/xenif.cpp
+++ b/src/xenusbdevice/xenif.cpp
@@ -226,7 +226,7 @@ AllocateXenInterface(
     PUSB_FDO_CONTEXT fdoContext)
 {
     PXEN_INTERFACE xen = (PXEN_INTERFACE)
-                         ExAllocatePoolWithTag(NonPagedPool, sizeof(XEN_INTERFACE), XVU9);
+                         ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(XEN_INTERFACE), XVU9);
 
     if (!xen)
     {
@@ -301,11 +301,9 @@ static VOID
 XenRegisterSuspendHandler(
     IN PXEN_INTERFACE Xen)
 {
-    NTSTATUS status;
-
     Trace("====>\n");
 #if 0
-    status = XENBUS_SUSPEND(Register,
+    NTSTATUS status = XENBUS_SUSPEND(Register,
                             &Xen->SuspendInterface,
                             SUSPEND_CALLBACK_LATE,
                             ResumeCallback,
@@ -316,6 +314,8 @@ XenRegisterSuspendHandler(
     {
         TraceError("failed to register suspend handler.\n");
     }
+#else 
+    UNREFERENCED_PARAMETER(Xen);
 #endif
     Trace("<====\n");
 }
@@ -333,17 +333,21 @@ XenUnregisterSuspendHandler(
                    &Xen->SuspendInterface,
                    Xen->SuspendCallbackLate);
     Xen->SuspendCallbackLate = NULL;
+#else 
+    UNREFERENCED_PARAMETER(Xen);
 #endif
     Trace("====>\n");
 }
 
 static PMDL
 XenAllocatePage(VOID)
+#pragma warning(push)
+#pragma warning(disable: 6014) // Leaking memory 'buf'
 {
     PMDL mdl;
     PVOID buf;
 
-    buf = ExAllocatePoolWithTag(NonPagedPool, PAGE_SIZE, XVU9);
+    buf = ExAllocatePool2(POOL_FLAG_NON_PAGED, PAGE_SIZE, XVU9);
     if (buf == NULL)
     {
         TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
@@ -351,7 +355,7 @@ XenAllocatePage(VOID)
         return NULL;
     }
 
-    mdl = (PMDL)ExAllocatePoolWithTag(NonPagedPool, MmSizeOfMdl(buf, PAGE_SIZE), XVU9);
+    mdl = (PMDL)ExAllocatePool2(POOL_FLAG_NON_PAGED, MmSizeOfMdl(buf, PAGE_SIZE), XVU9);
     if (mdl == NULL)
     {
         TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE,
@@ -365,6 +369,7 @@ XenAllocatePage(VOID)
 
     return mdl;
 }
+#pragma warning(pop)
 
 static BOOLEAN
 XenCreateSring(
@@ -663,7 +668,7 @@ XenDeviceInit(
     status = RtlStringCbPrintfA(
                  Xen->FrontendPath,
                  sizeof(Xen->FrontendPath),
-                 "device/vusb/%d",
+                 "device/vusb/%u",
                  Xen->DeviceId);
 
     if (status != STATUS_SUCCESS)
@@ -894,7 +899,7 @@ XenDeviceInitialize(
     FRONT_RING_INIT(&Xen->Ring, Xen->Sring, PAGE_SIZE);
 
     Xen->ShadowArrayEntries = SHADOW_ENTRIES;
-    Xen->Shadows = (usbif_shadow_ex_t *)ExAllocatePoolWithTag(NonPagedPool,
+    Xen->Shadows = (usbif_shadow_ex_t *)ExAllocatePool2(POOL_FLAG_NON_PAGED,
                    sizeof(usbif_shadow_ex_t)* SHADOW_ENTRIES,
                    XVUA);
     if (!Xen->Shadows)
@@ -906,7 +911,7 @@ XenDeviceInitialize(
     }
     RtlZeroMemory(Xen->Shadows, sizeof(usbif_shadow_ex_t)* SHADOW_ENTRIES);
 
-    Xen->ShadowFreeList = (PUSHORT)ExAllocatePoolWithTag(NonPagedPool,
+    Xen->ShadowFreeList = (PUSHORT)ExAllocatePool2(POOL_FLAG_NON_PAGED,
                           sizeof(USHORT)* SHADOW_ENTRIES,
                           XVUB);
     if (!Xen->ShadowFreeList)
@@ -2312,8 +2317,8 @@ PutUrbOnRing(
                 ASSERT(indirectPagesNeeded <= MAX_INDIRECT_PAGES);
 #pragma warning(push)
 #pragma warning(disable: 28197)
-                shadow->indirectPageMemory = ExAllocatePoolWithTag(
-                                                 NonPagedPool,
+                shadow->indirectPageMemory = ExAllocatePool2(
+                                                 POOL_FLAG_NON_PAGED,
                                                  (PAGE_SIZE * indirectPagesNeeded),
                                                  XVUC);
 #pragma warning(pop)
@@ -2547,8 +2552,7 @@ PutIsoUrbOnRing(
         transferLength = Urb->UrbIsochronousTransfer.TransferBufferLength;
         numberOfPackets = Urb->UrbIsochronousTransfer.NumberOfPackets;
 
-        packetBuffer = (iso_packet_info *)  ExAllocatePoolWithTag(NonPagedPool,
-        PAGE_SIZE, XVUD);
+        packetBuffer = (iso_packet_info *)  ExAllocatePool2(POOL_FLAG_NON_PAGED, PAGE_SIZE, XVUD);
 
         if (!packetBuffer)
         {
@@ -2693,8 +2697,8 @@ PutIsoUrbOnRing(
             ASSERT(indirectPagesNeeded <= MAX_INDIRECT_PAGES);
 #pragma warning(push)
 #pragma warning(disable: 28197)
-            shadow->indirectPageMemory = ExAllocatePoolWithTag(
-                                             NonPagedPool,
+            shadow->indirectPageMemory = ExAllocatePool2(
+                                             POOL_FLAG_NON_PAGED,
                                              (PAGE_SIZE * indirectPagesNeeded),
                                              XVUE);
 #pragma warning(pop)

--- a/vs2022/xenusbdevice/xenusbdevice.vcxproj
+++ b/vs2022/xenusbdevice/xenusbdevice.vcxproj
@@ -32,7 +32,7 @@
       <PreprocessorDefinitions>__MODULE__="XENUSBDEVICE";POOL_NX_OPTIN=1;NT_PROCESSOR_GROUPS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\include;..\..\include\xen;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>EnableAllWarnings</WarningLevel>
-      <DisableSpecificWarnings>4061;4464;4514;4711;4548;4820;4668;4255;5045;6001;6054;28196;30030;30029;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4514;4820;5045;30030;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnablePREfast>true</EnablePREfast>
       <TreatWarningAsError>false</TreatWarningAsError>


### PR DESCRIPTION
Replace deprecated ExAllocatePoolWithTag with ExAllocatePool2
Change all non-paged allocations to no execute
Remove unused variables
Fix initializer of subgroup
Fix sign error
Fix unused parameters/local under conditional compilation
Fix type conversions and add explicit casts
Disable warning that buf is leaking (freed later - if not, this warning doesn't prevent that anyway)
Remove superfluous warning disables (prevent hiding of issues)